### PR TITLE
Add Travis-ci support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    "utils": "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+---
+env:
+- PUPPET_VERSION=2.7.13
+- PUPPET_VERSION=3.2.3
+notifications:
+email: false
+rvm:
+- 1.9.3
+- 1.8.7
+matrix:
+  allow_failures:
+  - env: PUPPET_VERSION=2.7.13
+language: ruby
+before_script: "gem install --no-ri --no-rdoc bundler"
+script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
+gemfile: Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 2.7']
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 0.1.0'
+gem 'puppet-lint', '>= 0.3.2'
+gem 'facter', '>= 1.7.0', "< 1.8.0"

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'ghoneycutt-utils'
-version '2.0.0'
+version '2.0.1'
 source 'git://github.com/ghoneycutt/puppet-module-utils.git'
 author 'ghoneycutt'
 license 'Apache License, Version 2.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,12 @@
 require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp"]
+
+desc "Run puppet in noop mode and check for syntax errors."
+task :validate do
+   Dir['manifests/**/*.pp'].each do |path|
+     sh "puppet parser validate --noop #{path}"
+   end
+end


### PR DESCRIPTION
This patch enables testing on travis-ci.org. It checks that manifests
pass parser validation and puppet-lint and then checks that all spec
tests pass.
