### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 env:
 - PUPPET_VERSION=2.7.23
-- PUPPET_VERSION=3.2.4
+- PUPPET_VERSION=3.3.2
 notifications:
 email: false
 rvm:

--- a/Rakefile
+++ b/Rakefile
@@ -6,11 +6,11 @@ PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Run puppet in noop mode and check for syntax errors."
 task :validate do
-  Dir['manifests/**/*.pp'].each do |path|
-    sh "puppet parser validate --noop #{path}"
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
   end
-  Dir['spec/**/*.rb','lib/**/*.rb'].each do |spec_path|
-    sh "ruby -c #{spec_path}" unless spec_path =~ /spec\/fixtures/
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
   end
   Dir['templates/**/*.erb'].each do |template|
     sh "erb -P -x -T '-' #{template} | ruby -c"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -51,7 +51,7 @@ describe 'utils' do
 
     it 'should fail' do
       expect {
-        should include_class('types')
+        should contain_class('types')
       }.to raise_error(Puppet::Error)
     end
   end


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
